### PR TITLE
Adds gradle.properties back in, sources online say it is good to put …

### DIFF
--- a/android/app/gradle.properties
+++ b/android/app/gradle.properties
@@ -1,0 +1,6 @@
+android.useDeprecatedNdk=true
+
+MYAPP_RELEASE_STORE_FILE=my-release-key.keystore
+MYAPP_RELEASE_KEY_ALIAS=devise
+MYAPP_RELEASE_STORE_PASSWORD=EA64dhpd
+MYAPP_RELEASE_KEY_PASSWORD=EA64dhpd


### PR DESCRIPTION
…it under git tracking my-release-key.keystore stays out of tracking